### PR TITLE
Refresh UI when PSTN hangs up

### DIFF
--- a/public/js/client.js
+++ b/public/js/client.js
@@ -8,6 +8,8 @@ document.addEventListener('DOMContentLoaded', async () => {
   application = await client.login(jwt);
   notifications.innerHTML = `You are logged in as ${application.me.name}`;
 
+  let conversation = null;
+
   // Whenever a call is made bind an event that ends the call to
   // the hangup button
   application.on("member:call", (member, call) => {
@@ -17,6 +19,16 @@ document.addEventListener('DOMContentLoaded', async () => {
       btnHangup.removeEventListener('click', terminateCall)
     };
     btnHangup.addEventListener('click', terminateCall);
+  });
+
+  // During a call, retrieve the Conversation so that we can determine 
+  // if a Member leaves and change the state of the button
+  application.on("call:status:changed", (nxmCall) => {
+    console.log(`Call status: ${nxmCall.status}`);
+    conversation = nxmCall.conversation;
+    conversation.on("member:left", (member, event) => {
+      toggleCallStatusButton('idle');
+    });
   });
 
   // Whenever we click the call button, trigger a call to the support number

--- a/public/js/client.js
+++ b/public/js/client.js
@@ -19,13 +19,10 @@ document.addEventListener('DOMContentLoaded', async () => {
       btnHangup.removeEventListener('click', terminateCall)
     };
     btnHangup.addEventListener('click', terminateCall);
-  });
 
-  // During a call, retrieve the Conversation so that we can determine 
-  // if a Member leaves and change the state of the button
-  application.on("call:status:changed", (nxmCall) => {
-    console.log(`Call status: ${nxmCall.status}`);
-    conversation = nxmCall.conversation;
+    // Retrieve the Conversation so that we can determine if a 
+    // Member has left and refresh the button state
+    conversation = call.conversation;
     conversation.on("member:left", (member, event) => {
       toggleCallStatusButton('idle');
     });


### PR DESCRIPTION
The client didn't "know" when the PSTN end of the call left the conversation. Added event handling to fix this.